### PR TITLE
Support users with multiple discord aliases

### DIFF
--- a/src/handlers/cred.js
+++ b/src/handlers/cred.js
@@ -11,7 +11,7 @@ const filterAccount = (obj, targetUserDiscordID) => {
   const discordAlias = obj.account.identity.aliases.filter(
     alias => {
       const parts = NodeAddress.toParts(alias.address)
-      return parts.indexOf('discord') > 0
+      return parts.indexOf('discord') > 0 && parts.indexOf(targetUserDiscordID) > 0
     })
   if (discordAlias.length === 1) {
     // Retrieve the Discord ID


### PR DESCRIPTION
# Description
Prior to this change, users with multiple discord aliases are not supported by the !cred command. This change will fix that.

# Test Plan
This change is untested. Please advise on how to test, or please help with testing.